### PR TITLE
Update aws_session_token to session_token

### DIFF
--- a/3-enrich/emr-etl-runner/Gemfile
+++ b/3-enrich/emr-etl-runner/Gemfile
@@ -21,7 +21,7 @@ ruby "1.9.3"
 # RubyGems it requires here.
 gem "contracts", "= 0.7"
 gem "elasticity", "~> 6.0.7"
-gem "sluice", "~> 0.2.2"
+gem "sluice", "~> 0.2.3"
 gem "awrence", "~> 0.1.0"
 gem "snowplow-tracker", "~> 0.5.2"
 gem "aws-sdk", "~> 2"

--- a/3-enrich/emr-etl-runner/Gemfile.lock
+++ b/3-enrich/emr-etl-runner/Gemfile.lock
@@ -100,7 +100,7 @@ GEM
       json (~> 1.8)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.0)
-    sluice (0.2.2)
+    sluice (0.2.3)
       contracts (~> 0.4)
       fog (= 1.24)
     snowplow-tracker (0.5.2)
@@ -130,7 +130,7 @@ DEPENDENCIES
   coveralls
   elasticity (~> 6.0.7)
   rspec (~> 2.14, >= 2.14.1)
-  sluice (~> 0.2.2)
+  sluice (~> 0.2.3)
   snowplow-tracker (~> 0.5.2)
   warbler
 

--- a/3-enrich/emr-etl-runner/lib/snowplow-emr-etl-runner/emr_job.rb
+++ b/3-enrich/emr-etl-runner/lib/snowplow-emr-etl-runner/emr_job.rb
@@ -103,14 +103,12 @@ module Snowplow
 
         # Configure Elasticity with your AWS credentials
         Elasticity.configure do |c|
- +        if config[:aws][:access_key_id] == 'iam' and config[:aws][:secret_access_key] == 'iam'
-            #federated Identity Management
- +          credentials_from_role = Aws::InstanceProfileCredentials.new.credentials
- +          c.access_key = credentials_from_role.access_key_id
- +          c.secret_key = credentials_from_role.secret_access_key
- +          c.session_token = credentials_from_role.aws_session_token
- +        else
-            #values in config
+          if ( config[:aws][:access_key_id] == 'iam' && config[:aws][:secret_access_key] == 'iam' )
+            credentials_from_role = Aws::InstanceProfileCredentials.new.credentials
+            c.access_key = credentials_from_role.access_key_id
+            c.secret_key = credentials_from_role.secret_access_key
+            c.session_token = credentials_from_role.session_token
+          else
             c.access_key = config[:aws][:access_key_id]
             c.secret_key = config[:aws][:secret_access_key]
           end

--- a/3-enrich/emr-etl-runner/lib/snowplow-emr-etl-runner/emr_job.rb
+++ b/3-enrich/emr-etl-runner/lib/snowplow-emr-etl-runner/emr_job.rb
@@ -107,7 +107,7 @@ module Snowplow
             credentials_from_role = Aws::InstanceProfileCredentials.new.credentials
             c.access_key = credentials_from_role.access_key_id
             c.secret_key = credentials_from_role.secret_access_key
-            c.session_token = credentials_from_role.session_token
+            c.security_token = credentials_from_role.session_token
           else
             c.access_key = config[:aws][:access_key_id]
             c.secret_key = config[:aws][:secret_access_key]


### PR DESCRIPTION
changed name from aws_session_token to session_token per documentation here:
http://docs.aws.amazon.com/sdkforruby/api/Aws/InstanceProfileCredentials.html
